### PR TITLE
Fixes the modal for adding events which expands off the screen

### DIFF
--- a/client/src/components/ui/add-event-modal-fixed.tsx
+++ b/client/src/components/ui/add-event-modal-fixed.tsx
@@ -70,8 +70,8 @@ const AddEventModal: FC<AddEventModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-3xl">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] flex flex-col p-0">
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0">
           <DialogTitle>Add New Event</DialogTitle>
           <DialogDescription>
             Enter the details of the event you want to add to the system.
@@ -79,8 +79,9 @@ const AddEventModal: FC<AddEventModalProps> = ({
         </DialogHeader>
         
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="flex flex-col flex-1 min-h-0">
+            <div className="flex-1 overflow-y-auto px-6 space-y-6">
+              <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
               {/* Event Name */}
               <FormField
                 control={form.control}
@@ -363,9 +364,10 @@ const AddEventModal: FC<AddEventModalProps> = ({
                   </FormItem>
                 )}
               />
+              </div>
             </div>
             
-            <DialogFooter>
+            <DialogFooter className="px-6 pt-4 pb-6 flex-shrink-0 border-t">
               <Button type="button" variant="outline" onClick={onClose}>
                 Cancel
               </Button>


### PR DESCRIPTION
The modal when you add events expands off the screen like so:

<img width="1054" height="884" alt="Screenshot 2025-10-30 at 4 55 44 PM" src="https://github.com/user-attachments/assets/2657cad9-f5d3-4fca-905c-6b02bb31a5d7" />

These changes ensures modal content should scroll; background scrolling should be disabled when the modal is open.

<img width="1067" height="873" alt="Screenshot 2025-10-30 at 4 55 28 PM" src="https://github.com/user-attachments/assets/2f5ac043-8e39-4ad8-8174-f921e654aba9" />
