### PR TITLE
Improve the calendar modal to fix some UX issues

### DIFF
--- a/client/src/components/ui/calendar.tsx
+++ b/client/src/components/ui/calendar.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
@@ -15,29 +14,33 @@ function Calendar({
 }: CalendarProps) {
   return (
     <DayPicker
+      fixedWeeks
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
-        nav_button: cn(
+        month: "relative space-y-4",
+        caption: "grid grid-cols-3 items-center pt-1 pb-2",
+        caption_label: "text-sm font-medium text-center col-start-2",
+        nav: "contents",
+        button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "h-9 w-9 p-0 col-start-1 justify-self-start text-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:fill-foreground dark:[&_svg]:fill-white"
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-y-1",
+        button_next: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-9 w-9 p-0 col-start-3 justify-self-end text-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:fill-foreground dark:[&_svg]:fill-white"
+        ),
+        table: "w-full border-collapse",
         head_row: "flex",
         head_cell:
-          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem] flex items-center justify-center",
         row: "flex w-full mt-2",
         cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-        day: cn(
+        day: "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
+        day_button: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+          "h-full w-full p-0 font-normal"
         ),
         day_range_end: "day-range-end",
         day_selected:
@@ -51,14 +54,6 @@ function Calendar({
         day_hidden: "invisible",
         ...classNames,
       }}
-      components={{
-        IconLeft: ({ className, ...props }: { className?: string; [key: string]: any }) => (
-          <ChevronLeft className={cn("h-4 w-4", className)} {...props} />
-        ),
-        IconRight: ({ className, ...props }: { className?: string; [key: string]: any }) => (
-          <ChevronRight className={cn("h-4 w-4", className)} {...props} />
-        ),
-      } as any}
       {...props}
     />
   )


### PR DESCRIPTION
Previously the calendar modal was difficult to move the dates, if the number of days in the month changed the arrows would move making quick navigation difficult.  Also the days of the week were in their own column element. 

<img width="543" height="394" alt="Screenshot 2025-10-30 at 5 00 48 PM" src="https://github.com/user-attachments/assets/2494b585-10bc-4fbb-8972-d08324340a51" />
<img width="547" height="349" alt="Screenshot 2025-10-30 at 5 00 43 PM" src="https://github.com/user-attachments/assets/80bfdd3f-243b-460d-8c8b-8f0b8b2a6795" />

- Updated the styling of the Calendar component to improve layout and responsiveness.
- Removed unused icon components and adjusted class names for better alignment and spacing.
- Enhanced button styles for navigation and day selection, ensuring a more consistent user experience.
- Introduced a fixed weeks feature to the DayPicker for improved calendar functionality.

The simplest fix moves these arrows to the side and adjusts the calendar so that it stays the same size no matter how many days.  

<img width="367" height="384" alt="Screenshot 2025-10-30 at 6 09 23 PM" src="https://github.com/user-attachments/assets/48295ab2-a8f1-4106-832d-bab0e4de5422" />
<img width="368" height="377" alt="Screenshot 2025-10-30 at 6 09 18 PM" src="https://github.com/user-attachments/assets/c55c59fe-3514-4fe3-980c-aeacb9f8630d" />

